### PR TITLE
Use new version of jade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-jade-plugin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Compile Jade templates to one JavaScript file (normal or AMD).",
   "keywords": [
     "gruntplugin"
@@ -31,7 +31,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "jade": "~0.27.7"
+    "jade": "~1.8.2"
   },
   "devDependencies": {
     "grunt": "~0.4.0",

--- a/tasks/jade.coffee
+++ b/tasks/jade.coffee
@@ -23,7 +23,6 @@ module.exports = (grunt) ->
     output = []
     nsInfo = getNamespaceDeclaration(options.namespace, options.amd)
     compilationOptions =
-      client: true
       compileDebug: options.compileDebug
 
     # Prepare Jade runtime.
@@ -36,7 +35,7 @@ module.exports = (grunt) ->
 
         try
           compilationOptions.filename = filepath
-          compiled = jade.compile(fileContents, compilationOptions)
+          compiled = jade.compileClient(fileContents, compilationOptions)
         catch errorMessage
           grunt.log.error errorMessage
           grunt.fail.warn "Jade failed to compile #{filepath}."


### PR DESCRIPTION
Hello,

With this little change, your plugin will use a newer version of jade, which is producing code that doesn't use `with` and is therefore compatible with JavaScript strict mode.